### PR TITLE
updated clusterRole to include creation of events

### DIFF
--- a/multus/Chart.yaml
+++ b/multus/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 name: multus
 description: Multus Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/intel/multus-cni
 icon: https://raw.githubusercontent.com/intel/multus-cni/master/doc/images/Multus.png
 sources:

--- a/multus/templates/clusterRole.yaml
+++ b/multus/templates/clusterRole.yaml
@@ -31,5 +31,11 @@ rules:
     verbs:
       - get
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
 {{- end }}
 {{- end }}


### PR DESCRIPTION
when using this multus chart I was getting the following error;

`{"log":"E0126 04:24:09.333912 1762818 event.go:203] Server rejected event '\u0026v1.Event{TypeMeta:v1.TypeMeta{Kind:\"\", APIVersion:\"\"}, ObjectMeta:v1.ObjectMeta{Name:\"appfwl-default-5d9c794d46-js7gd.165dad89def3bb77\", GenerateName:\"\", Namespace:\"***\", SelfLink:\"\", UID:\"\", ResourceVersion:\"\", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:\"\"}, InvolvedObject:v1.ObjectReference{Kind:\"Pod\", Namespace:\"***\", Name:\"*****\", UID:\"dc2d83f5-f812-4b13-956f-553955d30c69\", APIVersion:\"v1\", ResourceVersion:\"3038800\", FieldPath:\"\"}, Reason:\"AddedInterface\", Message:\"Add eth0 [******/32]\", Source:v1.EventSource{Component:\"multus\", Host:\"\"}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xbffc043a53bce177, ext:550059328, loc:(*time.Location)(0x1da7b40)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xbffc043a53bce177, ext:550059328, loc:(*time.Location)(0x1da7b40)}}, Count:1, Type:\"Normal\", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:\"\", Related:(*v1.ObjectReference)(nil), ReportingController:\"\", ReportingInstance:\"\"}': 'events is forbidden: User \"system:serviceaccount:kube-system:multus\" cannot create resource \"events\" in API group \"\" in the namespace \"****\"' (will not retry!)\n","stream":"stderr","time":"2021-01-26T04:24:09.334192288Z"}`

this PR adds the ability for multus to create events in the namespace