### PR TITLE
added new annotation/priorityClassName

### DIFF
--- a/multus/Chart.yaml
+++ b/multus/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 name: multus
 description: Multus Helm chart for Kubernetes
 type: application
-version: 0.1.1
+version: 0.1.2
 home: https://github.com/intel/multus-cni
 icon: https://raw.githubusercontent.com/intel/multus-cni/master/doc/images/Multus.png
 sources:

--- a/multus/templates/daemonSet.yaml
+++ b/multus/templates/daemonSet.yaml
@@ -32,7 +32,10 @@ spec:
     metadata:
       labels:
 {{- include "multus.labels" . | indent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
     spec:
+      priorityClassName: system-node-critical
       hostNetwork: true
       nodeSelector: {{- toYaml .Values.labels.nodeSelector | nindent 8 }}
       tolerations:

--- a/sriov/Chart.yaml
+++ b/sriov/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 name: sriov
 description: SR-IOV CNI Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/intel/sriov-network-device-plugin
 sources:
   - https://github.com/intel/sriov-network-device-plugin

--- a/sriov/templates/daemonSet_sriov_device_plugin.yaml
+++ b/sriov/templates/daemonSet_sriov_device_plugin.yaml
@@ -34,7 +34,10 @@ spec:
       labels:
 {{- include "sriov-dp.serviceAccount.Name" . | indent 8 }}
 {{- include "sriov-dp.labels" . | indent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configMap_sriov_device_plugin.yaml") . | sha256sum }}
     spec:
+      priorityClassName: system-node-critical
       hostNetwork: true
       nodeSelector: {{- toYaml .Values.labels.nodeSelector | nindent 8 }}
       tolerations:

--- a/whereabouts/Chart.yaml
+++ b/whereabouts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/whereabouts/templates/deployment.yaml
+++ b/whereabouts/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         name: whereabouts
         {{- include "whereabouts.selectorLabels" . | nindent 8 }}
     spec:
+      priorityClassName: system-node-critical
       hostNetwork: true
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Added a new annotation checksum/config. This annotation is a sha of the configmap, and when there are changes to the configmap this annotation will update. Since this annotation is in the pod template, this triggers a rolling restart of the deployment.

Added priorityClassName to all pods since these can be considered critical add-ons: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/