### PR TITLE
Use ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8 image

### DIFF
--- a/multus/values.yaml
+++ b/multus/values.yaml
@@ -19,8 +19,8 @@
 #replicaCount: 1
 
 image:
-  repository: docker.io/nfvpe/multus
-  tag: v3.4
+  repository: ghcr.io/k8snetworkplumbingwg/multus-cni
+  tag: v3.8
   pullPolicy: IfNotPresent
 
 #imagePullSecrets: []


### PR DESCRIPTION
v3.7.1 is the latest stable version of Multus CNI at the moment.
It's supposed to use stable versions by default in helm chart to
make it stable and production-ready.