### PR TITLE
Remove API deprecation warning on CRD

### DIFF
--- a/whereabouts/crds/whereabouts.cni.cncf.io_ippools.yaml
+++ b/whereabouts/crds/whereabouts.cni.cncf.io_ippools.yaml
@@ -1,61 +1,66 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: ippools.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io
   names:
     kind: IPPool
+    listKind: IPPoolList
     plural: ippools
-  scope: ""
-  validation:
-    openAPIV3Schema:
-      description: IPPool is the Schema for the ippools API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IPPoolSpec defines the desired state of IPPool
-          properties:
-            allocations:
-              additionalProperties:
-                description: IPAllocation represents metadata about the pod/container
-                  owner of a specific IP
-                properties:
-                  id:
-                    type: string
-                required:
-                - id
-                type: object
-              description: Allocations is the set of allocated IPs for the given range.
-                Its` indices are a direct mapping to the IP with the same index/offset
-                for the pool's range.
-              type: object
-            range:
-              description: Range is a RFC 4632/4291-style string that represents an
-                IP address and prefix length in CIDR notation
-              type: string
-          required:
-          - allocations
-          - range
-          type: object
-      type: object
-  version: v1alpha1
+    singular: ippool
+  scope: Namespaced
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPPool is the Schema for the ippools API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPPoolSpec defines the desired state of IPPool
+            properties:
+              allocations:
+                additionalProperties:
+                  description: IPAllocation represents metadata about the pod/container
+                    owner of a specific IP
+                  properties:
+                    id:
+                      type: string
+                    podref:
+                      type: string
+                  required:
+                  - id
+                  type: object
+                description: Allocations is the set of allocated IPs for the given
+                  range. Its` indices are a direct mapping to the IP with the same
+                  index/offset for the pool's range.
+                type: object
+              range:
+                description: Range is a RFC 4632/4291-style string that represents
+                  an IP address and prefix length in CIDR notation
+                type: string
+            required:
+            - allocations
+            - range
+            type: object
+        type: object
     served: true
     storage: true
 status:


### PR DESCRIPTION
This change is also in line with the example on:
<https://github.com/k8snetworkplumbingwg/whereabouts/blob/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml>