### PR TITLE
Support helm charts for network resource injector

### DIFF
--- a/network-resources-injector/.helmignore
+++ b/network-resources-injector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/network-resources-injector/Chart.yaml
+++ b/network-resources-injector/Chart.yaml
@@ -1,0 +1,24 @@
+# Copyright 2022 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v2
+name: network-resources-injector
+description: Network resource injector helm chart for Kubernetes
+type: application
+version: 0.1.0
+home: https://github.com/k8snetworkplumbingwg/network-resources-injector
+sources:
+  - https://github.com/k8snetworkplumbingwg/network-resources-injector
+maintainers:
+  - name: Network Plumbing Group
+appVersion: 1.3

--- a/network-resources-injector/templates/NOTES.txt
+++ b/network-resources-injector/templates/NOTES.txt
@@ -1,0 +1,5 @@
+network-resources-injector is installed!!
+
+You can view the pods with the following command:
+
+kubectl get pods -n kube-system -l app=network-resources-injector

--- a/network-resources-injector/templates/auth.yaml
+++ b/network-resources-injector/templates/auth.yaml
@@ -1,0 +1,162 @@
+# Copyright (c) 2022 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: kube-system
+  name: {{ .Values.serviceAccount.name }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secret.name }}
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: {{ .Values.serviceAccount.name }}
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Chart.Name }}
+rules:
+- apiGroups:
+  - ""
+  - k8s.cni.cncf.io
+  - extensions
+  - apps
+  resources:
+  - replicationcontrollers
+  - replicasets
+  - daemonsets
+  - statefulsets
+  - pods
+  - network-attachment-definitions
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.role.secretsName }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.role.webhookconfigName }}
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.role.serviceName }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.role.configmapsName }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - 'get'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.roleBinding.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.roleBinding.secretsName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.role.secretsName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.roleBinding.webhookconfigName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.role.webhookconfigName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.roleBinding.serviceName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.role.serviceName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.roleBinding.configmapsName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.role.configmapsName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: kube-system

--- a/network-resources-injector/templates/deployment.yaml
+++ b/network-resources-injector/templates/deployment.yaml
@@ -1,0 +1,99 @@
+# Copyright (c) 2022 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .Chart.Name }}
+  name: {{ .Chart.Name }}
+  namespace: kube-system
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      serviceAccount: {{ .Values.serviceAccount.name }}
+      containers:
+      - name: webhook-server
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - webhook
+        args:
+        - -bind-address={{ .Values.deployment.bindAddress }}
+        - -port={{ .Values.deployment.portNumber }}
+        - -tls-private-key-file=/etc/tls/tls.key
+        - -tls-cert-file=/etc/tls/tls.crt
+        - -logtostderr
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          runAsUser: 10000
+          runAsGroup: 10000
+          capabilities:
+            drop:
+              - ALL
+            add: ["NET_BIND_SERVICE"]
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /etc/tls
+          name: tls
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "250m"
+          limits:
+            memory: "200Mi"
+            cpu: "500m"
+{{- if .Values.manifests.thirdpartyCertificate }}
+      volumes:
+      - name: tls
+        secret:
+          secretName: {{ .Values.manifests.certificateSecretName }}
+{{ else }}
+      initContainers:
+      - name: installer
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - installer
+        args:
+        - -name={{ .Chart.Name }}
+        - -namespace=kube-system
+        - -alsologtostderr
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        securityContext:
+          runAsUser: 10000
+          runAsGroup: 10000
+        volumeMounts:
+        - name: tls
+          mountPath: /etc/tls
+      volumes:
+      - name: tls
+        emptyDir: {}
+{{- end }}

--- a/network-resources-injector/templates/pdb.yaml
+++ b/network-resources-injector/templates/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.pdb.name }}
+  namespace: kube-system
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}

--- a/network-resources-injector/templates/service.yaml
+++ b/network-resources-injector/templates/service.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2022 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  namespace: kube-system
+spec:
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: {{ .Values.service.targetPort }}
+  selector:
+    app: {{ .Chart.Name }}

--- a/network-resources-injector/templates/webhook.yaml
+++ b/network-resources-injector/templates/webhook.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2022 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.manifests.thirdpartyCertificate }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ .Values.webhookconf.name }}
+  namespace: kube-system
+webhooks:
+  - name: {{ .Values.webhookconf.webhook.name }}
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: {{ .Values.service.name }}
+        namespace: kube-sytem
+        path: "/mutate"
+      caBundle: {{ .Values.webhookconf.webhook.caBundle }}
+    namespaceSelector:
+      matchExpressions:
+        - key: "kubernetes.io/metadata.name"
+          operator: "NotIn"
+          values:
+            - "kube-system"
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: ["apps", ""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+{{- end }}

--- a/network-resources-injector/values.yaml
+++ b/network-resources-injector/values.yaml
@@ -1,0 +1,61 @@
+# Copyright 2022 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+deployment:
+  replicas: 2 
+  bindAddress: localhost
+  portNumber: 8443
+
+serviceAccount:
+  name: network-resources-injector-sa
+  
+secret:
+  name: network-resources-injector-sa-secret
+  
+role:
+  secretsName: network-resources-injector-secrets
+  webhookconfigName: network-resources-injector-webhook-configs
+  serviceName: network-resources-injector-service
+  configmapsName: network-resources-injector-configmaps
+  
+roleBinding:
+  name: network-resources-injector-role-binding
+  secretsName: network-resources-injector-secrets-role-binding
+  webhookconfigName: network-resources-injector-webhook-configs-role-binding
+  serviceName: network-resources-injector-service-role-binding
+  configmapsName: network-resources-injector-configmaps-role-binding
+    
+image:
+  repository: network-resources-injector
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  name: network-resources-injector-service
+  port: 443
+  targetPort: 8443
+
+webhookconf:
+  name: network-resources-injector-config
+  webhook:
+    name: network-resources-injector-config.k8s.io  
+    caBundle: # to be filled if manifests.thirdpartyCertificate is true
+
+pdb:
+  name: network-resources-injector-pdb
+  minAvailable: 1
+
+manifests:
+  thirdpartyCertificate: false
+  certificateSecretName: network-resources-injector-secret # will be used only when thirdpartyCertificate is true


### PR DESCRIPTION
Currently network resource injector does not support helm charts. This commit implements helm charts for nri.


Fixes: https://github.com/k8snetworkplumbingwg/network-resources-injector/issues/118