### PR TITLE
Only add multus-cfg when configmap is enabled

### DIFF
--- a/multus/templates/daemonSet.yaml
+++ b/multus/templates/daemonSet.yaml
@@ -73,9 +73,11 @@ spec:
           mountPath: /host/etc/cni/net.d
         - name: cnibin
           mountPath: /host/opt/cni/bin
+        {{- if .Values.manifests.configMap }}
         - name: multus-cfg
           mountPath: /tmp/multus-conf/00-multus.conf.template
           subPath: "cni-conf.json"
+        {{- end }}
       volumes:
         - name: cni
           hostPath:
@@ -83,8 +85,10 @@ spec:
         - name: cnibin
           hostPath:
             path: /opt/cni/bin
+        {{- if .Values.manifests.configMap }}
         - name: multus-cfg
           configMap:
             name: {{ .Release.Name }}-{{ .Chart.Name }}-{{ .Chart.Version }}-config
+        {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
If configmap is disabled in the values, it does not make sense that it gets part of the daemonset manifest

Signed-off-by: Manuel Buil <mbuil@suse.com>