### PR TITLE
whereabouts: fix deprecation warnings and update image to v0.5.2

### DIFF
--- a/whereabouts/templates/cluster_role.yaml
+++ b/whereabouts/templates/cluster_role.yaml
@@ -7,6 +7,7 @@ rules:
   - whereabouts.cni.cncf.io
   resources:
   - ippools
+  - overlappingrangeipreservations
   verbs:
   - get
   - list

--- a/whereabouts/templates/cronjob.yaml
+++ b/whereabouts/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "whereabouts.fullname" . }}

--- a/whereabouts/values.yaml
+++ b/whereabouts/values.yaml
@@ -3,10 +3,10 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: docker.io/dougbtv/whereabouts
+  repository: ghcr.io/k8snetworkplumbingwg/whereabouts
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: v0.5.2-amd64
 
 updateStrategy: RollingUpdate
 imagePullSecrets: []
@@ -40,7 +40,7 @@ resources:
     memory: "50Mi"
 
 nodeSelector:
-  beta.kubernetes.io/arch: amd64
+  kubernetes.io/arch: amd64
 
 tolerations:
   - operator: Exists


### PR DESCRIPTION
- Remove beta annotations to suppress deprecation warnings
- Update image to v0.5.2 and use ghcr repo