### PR TITLE
Remove duplicate label from whereabouts

### DIFF
--- a/whereabouts/templates/_helpers.tpl
+++ b/whereabouts/templates/_helpers.tpl
@@ -45,7 +45,6 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "whereabouts.labels" -}}
-app: whereabouts
 helm.sh/chart: {{ include "whereabouts.chart" . }}
 {{ include "whereabouts.selectorLabels" . }}
 {{- if .Chart.AppVersion }}


### PR DESCRIPTION
Installing the helm chart shows this error:
```
error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 10: mapping key "app" already defined at line 8
```

This closes #15