### PR TITLE
whereabouts: update charts to pass `spec.nodeName` to pod

### DIFF
--- a/whereabouts/templates/cluster_role.yaml
+++ b/whereabouts/templates/cluster_role.yaml
@@ -28,6 +28,11 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs:
+  - get
 - apiGroups: ["k8s.cni.cncf.io"]
   resources:
   - network-attachment-definitions

--- a/whereabouts/templates/daemonset.yaml
+++ b/whereabouts/templates/daemonset.yaml
@@ -37,6 +37,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+          - name: NODENAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
           - name: WHEREABOUTS_NAMESPACE
             valueFrom:
               fieldRef:


### PR DESCRIPTION
Update DaemonSet to pass `spec.nodeName` via a new `NODENAME` environment variable.

Introduced by whereabouts v0.6.2:
https://github.com/k8snetworkplumbingwg/whereabouts/pull/309