### PR TITLE
[cronjob] Sets apiVersion to batch/v1, fixes the binary name

### DIFF
--- a/whereabouts/templates/cronjob.yaml
+++ b/whereabouts/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "whereabouts.fullname" . }}
@@ -33,7 +33,7 @@ spec:
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
               command:
-                - /ip-reconciler
+                - /ip-control-loop
                 - -log-level=verbose
               volumeMounts:
                 - name: cni-net-dir


### PR DESCRIPTION
CronJob is stable since Kubernetes v1.21
Binary name update to match what's in ghcr.io/k8snetworkplumbingwg/whereabouts

Fixes #17 