### PR TITLE
Update cronjob.yaml

### DIFF
--- a/whereabouts/templates/cronjob.yaml
+++ b/whereabouts/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "whereabouts.fullname" . }}


### PR DESCRIPTION
Cronjob object reached GA on Kubernetes 1.21 and apiVersion is now batch/v1