### PR TITLE
Update whereabouts values.yaml to run on arm64

### DIFF
--- a/whereabouts/values.yaml
+++ b/whereabouts/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: ghcr.io/k8snetworkplumbingwg/whereabouts
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest-amd64"
+  tag: "latest"
 
 updateStrategy: RollingUpdate
 imagePullSecrets: []
@@ -41,7 +41,7 @@ resources:
     memory: "50Mi"
 
 nodeSelector:
-  beta.kubernetes.io/arch: amd64
+  kubernetes.io/os: linux
 
 tolerations:
   - operator: Exists


### PR DESCRIPTION
Whereabouts already provides arm64 images but the helm chart was still forcing amd64 only